### PR TITLE
Fix inline checkbox layout on formpack forms

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -231,6 +231,19 @@ body {
   border-radius: 8px;
 }
 
+.formpack-form input[type='checkbox'] {
+  width: auto;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+}
+
+.formpack-form label:has(> input[type='checkbox']) {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .formpack-form fieldset {
   margin: 0;
   padding: 1rem;


### PR DESCRIPTION
### Motivation
- Checkbox inputs were inheriting the generic `input/textarea/select { width: 100% }` rule which made boolean fields render on multiple lines and broke alignment. 
- Boolean fields such as ME/CFS, POTS and Long Covid need the checkbox and label text on the same row across viewports. 
- The change should not regress full-width text inputs or affect non-formpack pages.

### Description
- Add a scoped rule `.formpack-form input[type='checkbox']` to unset `width`, `max-width`, `padding` and `margin` so checkboxes do not stretch. 
- Add a scoped rule `.formpack-form label:has(> input[type='checkbox'])` to `display: inline-flex; align-items: center; gap: 0.5rem` so checkbox and label text sit on one line. 
- Scope changes to the `.formpack-form` container to avoid global regressions. 
- Modified file: `app/src/index.css` (small CSS-only change).

### Testing
- Ran `npm run lint` in `app` and it completed successfully. 
- Ran `npm run format:check` (Prettier) in `app` and it completed successfully. 
- Ran `npm run typecheck` (`tsc --noEmit`) in `app` and it completed successfully. 
- Ran `npm run build` in `app` and the production build completed successfully, and `npm run test` is not defined in `app/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a9d0a66c833392f01bdd646e1525)