### PR TITLE
Persist form reset, wire reset button, add tests, and fix E2E DB setup

### DIFF
--- a/app/e2e/reset-form.spec.ts
+++ b/app/e2e/reset-form.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type DbOptions = {
+  dbName: string;
+  storeName: string;
+};
+
+const FORM_PACK_ID = 'notfallpass';
+const ACTIVE_RECORD_KEY = `mecfs-paperwork.activeRecordId.${FORM_PACK_ID}`;
+
+const DB: DbOptions = {
+  dbName: 'mecfs-paperwork',
+  storeName: 'records',
+};
+
+const deleteDatabase = async (page: Page, dbName: string) => {
+  await page.evaluate(async (name) => {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  }, dbName);
+};
+
+const getActiveRecordId = async (page: Page) => {
+  return page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    ACTIVE_RECORD_KEY,
+  );
+};
+
+const waitForActiveRecordId = async (page: Page) => {
+  let activeId = '';
+  await expect
+    .poll(
+      async () => {
+        activeId = (await getActiveRecordId(page)) ?? '';
+        return activeId;
+      },
+      { timeout: 10_000, intervals: [250, 500, 1000] },
+    )
+    .not.toBe('');
+  return activeId;
+};
+
+const readRecordById = async (
+  page: Page,
+  id: string,
+  options: DbOptions = DB,
+) => {
+  return page.evaluate(
+    async ({ dbName, storeName, id }) => {
+      const openExistingDb = async () => {
+        if (indexedDB.databases) {
+          const databases = await indexedDB.databases();
+          if (!databases.some((db) => db.name === dbName)) {
+            return null;
+          }
+        }
+
+        return await new Promise<IDBDatabase | null>((resolve) => {
+          let aborted = false;
+          const request = indexedDB.open(dbName);
+          request.onupgradeneeded = () => {
+            aborted = true;
+            request.transaction?.abort();
+          };
+          request.onsuccess = () => {
+            const db = request.result;
+            if (aborted) {
+              db.close();
+              resolve(null);
+              return;
+            }
+            resolve(db);
+          };
+          request.onerror = () => resolve(null);
+          request.onblocked = () => resolve(null);
+        });
+      };
+
+      const db = await openExistingDb();
+      if (!db) return null;
+
+      try {
+        if (!db.objectStoreNames.contains(storeName)) return null;
+
+        return await new Promise<any>((resolve, reject) => {
+          const tx = db.transaction(storeName, 'readonly');
+          const store = tx.objectStore(storeName);
+          const getReq = store.get(id);
+          getReq.onerror = () => reject(getReq.error);
+          getReq.onsuccess = () => resolve(getReq.result ?? null);
+        });
+      } finally {
+        db.close();
+      }
+    },
+    { ...options, id },
+  );
+};
+
+const waitForRecordListReady = async (page: Page) => {
+  await page.waitForFunction(() => {
+    const empty = document.querySelector('.formpack-records__empty');
+    if (empty) {
+      const text = empty.textContent?.toLowerCase() ?? '';
+      return !text.includes('loading') && !text.includes('geladen');
+    }
+    return true;
+  });
+};
+
+const clickNewDraftIfNeeded = async (page: Page) => {
+  const nameInput = page.locator('#root_person_name');
+  const existingActiveId = await getActiveRecordId(page);
+  if (existingActiveId) {
+    await expect(nameInput).toBeVisible();
+    return;
+  }
+
+  await waitForRecordListReady(page);
+
+  const newDraftButton = page.getByRole('button', {
+    name: /new\s*draft|neuer\s*entwurf/i,
+  });
+  if (await newDraftButton.count()) {
+    await newDraftButton.first().click();
+  } else {
+    await page
+      .locator('.formpack-records__actions .app__button')
+      .first()
+      .click();
+  }
+
+  await waitForActiveRecordId(page);
+  await expect(nameInput).toBeVisible();
+};
+
+const waitForRecordData = async (
+  page: Page,
+  id: string,
+  check: (data: Record<string, unknown> | null) => boolean,
+) => {
+  await expect
+    .poll(
+      async () => {
+        const record = await readRecordById(page, id);
+        if (!record || !record.data) {
+          return false;
+        }
+        return check(record.data as Record<string, unknown>);
+      },
+      { timeout: 10_000, intervals: [250, 500, 1000] },
+    )
+    .toBe(true);
+};
+
+test.describe('reset form', () => {
+  test('clears the draft and persists after reload', async ({ page }) => {
+    await page.goto(`/formpacks/${FORM_PACK_ID}`);
+    await deleteDatabase(page, DB.dbName);
+    await page.reload();
+
+    await clickNewDraftIfNeeded(page);
+
+    const nameInput = page.locator('#root_person_name');
+    await nameInput.fill('Test Person');
+    await expect(nameInput).toHaveValue('Test Person');
+
+    const activeId = await waitForActiveRecordId(page);
+    await waitForRecordData(page, activeId, (data) => {
+      const person = data.person as Record<string, unknown> | undefined;
+      return person?.name === 'Test Person';
+    });
+
+    await page
+      .getByRole('button', {
+        name: /form.*zurücksetzen|reset\s*form/i,
+      })
+      .click();
+
+    await expect(nameInput).toHaveValue('');
+
+    await waitForRecordData(page, activeId, (data) => {
+      return Object.keys(data).length === 0;
+    });
+
+    await page.reload();
+
+    await expect(nameInput).toHaveValue('');
+
+    await waitForRecordData(page, activeId, (data) => {
+      return Object.keys(data).length === 0;
+    });
+  });
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,6 +23,7 @@
         "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.0.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -143,7 +144,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -522,7 +522,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -566,7 +565,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1357,7 +1355,6 @@
       "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-6.1.2.tgz",
       "integrity": "sha512-Px3FIkE1KK0745Qng9v88RZ0O7hcLf/1JUu0j00g+r6C8Zyokna42Hz/5TKyyQSKJqgVYcj2Z47YroVLenUM3A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@x0k/json-schema-merge": "^1.0.2",
         "fast-uri": "^3.1.0",
@@ -1831,12 +1828,27 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1920,7 +1932,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1938,7 +1949,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1950,7 +1960,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1995,7 +2004,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2308,7 +2316,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2537,7 +2544,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2850,7 +2856,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -2968,7 +2975,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3615,7 +3621,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -3844,7 +3849,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4113,6 +4117,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4605,6 +4610,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4620,6 +4626,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4632,7 +4639,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4687,7 +4695,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4700,7 +4707,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5255,7 +5261,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5377,7 +5382,6 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5440,7 +5444,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6057,7 +6060,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6071,7 +6073,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,7 @@
     "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.0.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/app/src/pages/FormpackDetailPage.test.tsx
+++ b/app/src/pages/FormpackDetailPage.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import FormpackDetailPage from './FormpackDetailPage';
+
+const mockUpdateActiveRecord = vi.fn();
+const mockMarkAsSaved = vi.fn();
+
+const record = {
+  id: 'record-1',
+  formpackId: 'notfallpass',
+  title: 'Draft',
+  locale: 'de',
+  data: { field: 'value' },
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+vi.mock('@rjsf/core', () => ({
+  default: ({
+    children,
+    formData,
+    onChange,
+  }: {
+    children?: React.ReactNode;
+    formData?: Record<string, unknown>;
+    onChange?: (event: { formData: Record<string, unknown> }) => void;
+  }) => (
+    <div>
+      <div data-testid="form-data">{JSON.stringify(formData)}</div>
+      <button
+        type="button"
+        onClick={() => onChange?.({ formData: { field: 'value' } })}
+      >
+        trigger-change
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../i18n/formpack', () => ({
+  loadFormpackI18n: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../i18n/useLocale', () => ({
+  useLocale: () => ({
+    locale: 'de',
+    setLocale: vi.fn(),
+  }),
+}));
+
+vi.mock('../formpacks/documentModel', () => ({
+  buildDocumentModel: () => ({
+    diagnosisParagraphs: [],
+    person: { name: null, birthDate: null },
+    contacts: [],
+    diagnosesFormatted: null,
+    symptoms: null,
+    medications: [],
+    allergies: null,
+    doctor: { name: null, phone: null },
+  }),
+}));
+
+vi.mock('../formpacks/loader', () => ({
+  FormpackLoaderError: class extends Error {},
+  loadFormpackManifest: vi.fn().mockResolvedValue({
+    id: 'notfallpass',
+    version: '1.0.0',
+    titleKey: 'formpackTitle',
+    descriptionKey: 'formpackDescription',
+    defaultLocale: 'de',
+    locales: ['de', 'en'],
+    exports: [],
+    docx: {
+      templates: {
+        a4: 'template-a4.docx',
+        wallet: 'template-wallet.docx',
+      },
+      mapping: 'mapping.json',
+    },
+  }),
+  loadFormpackSchema: vi.fn().mockResolvedValue({
+    type: 'object',
+    properties: {},
+  }),
+  loadFormpackUiSchema: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../storage/hooks', () => ({
+  useRecords: () => ({
+    records: [record],
+    activeRecord: record,
+    isLoading: false,
+    hasLoaded: true,
+    errorCode: null,
+    createRecord: vi.fn(),
+    loadRecord: vi.fn(),
+    updateActiveRecord: mockUpdateActiveRecord,
+    applyRecordUpdate: vi.fn(),
+    setActiveRecord: vi.fn(),
+  }),
+  useSnapshots: () => ({
+    snapshots: [],
+    isLoading: false,
+    errorCode: null,
+    createSnapshot: vi.fn(),
+    loadSnapshot: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  useAutosaveRecord: () => ({
+    markAsSaved: mockMarkAsSaved,
+  }),
+}));
+
+const mockT = (key: string) => key;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'de' },
+  }),
+}));
+
+describe('FormpackDetailPage', () => {
+  beforeEach(() => {
+    mockUpdateActiveRecord.mockResolvedValue({
+      ...record,
+      data: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears the draft and persists the reset', async () => {
+    render(
+      <MemoryRouter initialEntries={['/formpacks/notfallpass']}>
+        <Routes>
+          <Route path="/formpacks/:id" element={<FormpackDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const triggerButton = await screen.findByText('trigger-change');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('form-data')).toHaveTextContent(
+        JSON.stringify({}),
+      ),
+    );
+
+    await userEvent.click(triggerButton);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('form-data')).toHaveTextContent(
+        JSON.stringify(record.data),
+      ),
+    );
+
+    await userEvent.click(await screen.findByText('formpackFormReset'));
+
+    await waitFor(() =>
+      expect(mockUpdateActiveRecord).toHaveBeenCalledWith(record.id, {
+        data: {},
+        locale: 'de',
+      }),
+    );
+    expect(mockUpdateActiveRecord).toHaveBeenCalledTimes(1);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('form-data')).toHaveTextContent(
+        JSON.stringify({}),
+      ),
+    );
+
+    expect(mockMarkAsSaved).toHaveBeenCalledWith({});
+  });
+});

--- a/app/src/pages/FormpackDetailPage.tsx
+++ b/app/src/pages/FormpackDetailPage.tsx
@@ -457,6 +457,23 @@ export default function FormpackDetailPage() {
     setFormData(event.formData as FormDataState);
   };
 
+  const handleResetForm = useCallback(async () => {
+    if (!activeRecord) {
+      return;
+    }
+
+    const clearedData: FormDataState = {};
+    setFormData(clearedData);
+
+    const updated = await updateActiveRecord(activeRecord.id, {
+      data: clearedData,
+      locale,
+    });
+    if (updated) {
+      markAsSaved(updated.data);
+    }
+  }, [activeRecord, locale, markAsSaved, updateActiveRecord]);
+
   const handleCreateRecord = useCallback(async () => {
     if (!manifest) {
       return;
@@ -1003,14 +1020,7 @@ export default function FormpackDetailPage() {
                       <button
                         type="button"
                         className="app__button"
-                        onClick={() => {
-                          if (!activeRecord) {
-                            return;
-                          }
-
-                          markAsSaved(activeRecord.data);
-                          setFormData(activeRecord.data);
-                        }}
+                        onClick={handleResetForm}
                       >
                         {t('formpackFormReset')}
                       </button>


### PR DESCRIPTION
### Motivation

- Ensure the form reset clears the active draft in the UI and persists the cleared state to storage so empty drafts remain cleared after reloads.  
- Prevent a Playwright `SecurityError` when deleting IndexedDB during E2E setup by adjusting when the DB is cleared.  
- Add unit and end-to-end coverage to prevent regressions around reset/persistence behavior.  
- Provide utilities and test dependencies needed for interaction testing (`user-event`).

### Description

- Implemented `handleResetForm` in `FormpackDetailPage` to clear `formData`, call `updateActiveRecord` with the cleared data, and call `markAsSaved` when persistence succeeds.  
- Wired the form reset button `onClick` to `handleResetForm` so the UI and persistence are updated immediately.  
- Added a unit test `app/src/pages/FormpackDetailPage.test.tsx` that asserts `updateActiveRecord` call args and `markAsSaved` invocation, and added an E2E test `app/e2e/reset-form.spec.ts` that validates clearing a draft and that the empty draft persists across reloads.  
- Fixed the E2E IndexedDB setup by navigating to the page before calling `deleteDatabase(page, ...)` and then reloading, and added `@testing-library/user-event` to `devDependencies` and `package-lock.json`.

### Testing

- Ran `npm ci` in `app` and the install completed successfully.  
- Ran `npm run lint` and `npm run format:check` (and applied formatting) and both checks passed.  
- Ran `npm run typecheck` and `npm run build` and both succeeded after adding the missing `@testing-library/user-event` dev dependency.  
- Note: Playwright E2E tests were added and an existing E2E failure motivated the fix, but the full E2E test suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625c6992008333b6f0c83c30709ca7)