### PR TITLE
Added documentation for risk acceptance

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      CSP: docx-templates relies on eval for DOCX generation. This is acceptable
+      here because templates are bundled and not user-supplied.
+    -->
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self' blob:; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; object-src 'none'; frame-ancestors 'none';"


### PR DESCRIPTION
Formpacks stay in our hands so build warning: "node_modules/docx-templates/lib/browser.js (17:6062): Use of eval in "node_modules/docx-templates/lib/browser.js" is strongly discouraged as it poses security risks and may cause issues with minification."   is accepted