### PR TITLE
Standardize test entrypoint (npm test) and update QA docs

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Unit tests
         working-directory: app
-        run: npm run test:unit
+        run: npm test
 
       - name: Build
         working-directory: app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ For every change that touches `app/`:
 3. `npm run format:check`
 4. `npm run typecheck`
 5. `npm run build`
-6. `npm run test:unit`
+6. `npm test`
 7. `npm run test:e2e`
 8. `npm run formpack:validate`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,12 @@ Optional (recommended): run the one-command helper script (Windows PowerShell):
 ```powershell
 . .\tools\run-quality-gates.ps1
 ```
+
+Optional (coverage report):
+
+```bash
+npm run test:coverage
+```
 ## Issues
 - Please create an issue to discuss your idea first before you use precious time for coding and testing.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ npm run formpack:validate
 npm run build
 ```
 
+Optional (Coverage-Report):
+
+```bash
+npm run test:coverage
+```
+
 ### One-Command Check (PowerShell)
 
 Im `tools/`-Ordner liegt ein Helper-Skript, das die Quality Gates automatisiert (inkl. optionalem Docker-Build + Smoke-Test):

--- a/app/package.json
+++ b/app/package.json
@@ -19,8 +19,10 @@
     "formpack:validate": "node scripts/validate-formpacks.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test": "npm run test:unit",
+    "test": "vitest --run",
     "test:unit": "vitest --run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest --run --coverage",
     "prepare": "husky",
     "precommit": "lint-staged"
   },

--- a/app/src/pages/FormpackDetailPage.test.tsx
+++ b/app/src/pages/FormpackDetailPage.test.tsx
@@ -210,7 +210,9 @@ describe('FormpackDetailPage', () => {
     const exportButton = await screen.findByText('formpackRecordExportDocx');
     await userEvent.click(exportButton);
 
-    await waitFor(() => expect(consoleSpy).toHaveBeenCalledWith('DOCX export failed:', error));
+    await waitFor(() =>
+      expect(consoleSpy).toHaveBeenCalledWith('DOCX export failed:', error),
+    );
     expect(
       await screen.findByText('formpackDocxExportError'),
     ).toBeInTheDocument();


### PR DESCRIPTION
### Motivation
- Unify the local and CI test entrypoint so `npm test` is the canonical command for unit tests and quality gates. 
- Provide developer convenience scripts for watch and coverage runs to improve DX when working on tests. 
- Keep CI, contributor docs and agent guidance consistent about the test command used in the repo. 
- Fix formatting issues surfaced by `format:check` to ensure CI formatting step passes.

### Description
- Reworked `app/package.json` scripts to make `test` run `vitest --run` and added `test:watch` and `test:coverage` (files changed: `app/package.json`).
- Updated the QA workflow to run `npm test` for the Unit tests step (file changed: `.github/workflows/qa.yml`).
- Documented the coverage script in `README.md` and `CONTRIBUTING.md`, and updated `AGENTS.md` quality-gate guidance to reference `npm test` (files changed: `README.md`, `CONTRIBUTING.md`, `AGENTS.md`).
- Applied Prettier-friendly formatting tweak to `app/src/pages/FormpackDetailPage.test.tsx` to satisfy `format:check`.

### Testing
- Ran `cd app && npm run lint` and it succeeded. 
- Ran `cd app && npm run format` and `cd app && npm run format:check` and both succeeded (formatting applied where necessary). 
- Ran `cd app && npm test` and the Vitest suite completed successfully with all unit tests passing (`34` tests passed). 
- Ran `cd app && npm run test:e2e` which failed because Playwright browser binaries are not installed in this environment and requires `npx playwright install` to run; `cd app && npm run formpack:validate` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696615ff492c8333bd5afb7886573a0c)