### PR TITLE
feat(ui): add custom chevron to language selector

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,17 +28,36 @@ export default function App() {
           </div>
           <div className="app__locale-switch">
             <label htmlFor="locale-select">{t('languageLabel')}</label>
-            <select
-              id="locale-select"
-              value={locale}
-              onChange={handleLocaleChange}
-            >
-              {supportedLocales.map((optionLocale) => (
-                <option key={optionLocale} value={optionLocale}>
-                  {t(`languageOptions.${optionLocale}`)}
-                </option>
-              ))}
-            </select>
+            <div className="app__select-wrapper">
+              <select
+                id="locale-select"
+                value={locale}
+                onChange={handleLocaleChange}
+              >
+                {supportedLocales.map((optionLocale) => (
+                  <option key={optionLocale} value={optionLocale}>
+                    {t(`languageOptions.${optionLocale}`)}
+                  </option>
+                ))}
+              </select>
+              <svg
+                className="app__select-chevron"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4.66602 6.66602L7.99935 9.99935L11.3327 6.66602"
+                  stroke="#6B7280"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </header>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -65,10 +65,25 @@ body {
 }
 
 .app__locale-switch select {
-  padding: 0.4rem 0.6rem;
+  padding: 0.4rem 2rem 0.4rem 0.6rem;
   border-radius: 8px;
   border: 1px solid #d1d5db;
-  background: #ffffff;
+  background-color: #ffffff;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.app__select-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.app__select-chevron {
+  position: absolute;
+  right: 0.6rem;
+  pointer-events: none;
 }
 
 .app__content {


### PR DESCRIPTION
Replaces the default browser dropdown arrow on the language selector with a custom, consistently styled SVG chevron icon. This enhances the visual polish and ensures a consistent user experience across different browsers.

The implementation involves:
- Wrapping the `<select>` element in a relative-positioned `<div>`.
- Adding an inline SVG for the chevron icon.
- Applying CSS to hide the default browser arrow (`appearance: none`) and position the custom icon.
- Ensuring the SVG is hidden from screen readers with `aria-hidden="true"`.