### PR TITLE
Add Docker Compose smoke checks to CI

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -2,6 +2,9 @@ name: Docker smoke test
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -52,3 +55,44 @@ jobs:
       - name: Stop container
         if: always() && steps.check-secrets.outputs.available == 'true'
         run: docker stop mecfs-paperwork
+
+  docker-compose-smoke:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check secrets
+        id: check-secrets
+        env:
+          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
+          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+        run: |
+          if [ -n "$DHI_USERNAME" ] && [ -n "$DHI_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to dhi.io
+        if: steps.check-secrets.outputs.available == 'true'
+        run: echo "$DHI_TOKEN" | docker login dhi.io -u "$DHI_USERNAME" --password-stdin
+        env:
+          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
+          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+
+      - name: Compose up
+        if: steps.check-secrets.outputs.available == 'true'
+        run: docker compose up -d --build
+
+      - name: Compose smoke checks
+        if: steps.check-secrets.outputs.available == 'true'
+        run: |
+          curl -f http://localhost:8080/
+          curl -f http://localhost:8080/some/deep/link
+
+      - name: Compose down
+        if: always() && steps.check-secrets.outputs.available == 'true'
+        run: docker compose down


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass `compose.yaml` nicht unbemerkt bricht und dass `docker compose` (Build + Run + Health/SPA-fallback) in CI weiterhin funktioniert.
- Den Compose-spezifischen Check nur in vertrauenswürdigen Runs ausführen, damit Repository-Secrets für Login/Build verfügbar sind.

### Description
- Füge `push`-Trigger für `main` zu `.github/workflows/docker-smoke.yml` hinzu, damit der Workflow auch bei Main-Pushes läuft.
- Ergänze einen neuen Job `docker-compose-smoke`, der `Check secrets`, optionales `docker login`, `docker compose up -d --build`, Smoke-Checks via `curl -f http://localhost:8080/` und `curl -f http://localhost:8080/some/deep/link` sowie abschließend `docker compose down` ausführt.
- Gate den Job auf nicht-fork PRs / Main-Pushes mit derselben `if`-Bedingung wie der bestehende Docker-Job, damit Secrets nur in vertrauenswürdigen Läufen verwendet werden.
- Änderungen an der Datei `.github/workflows/docker-smoke.yml` wurden lokal geprüft mit `nl -ba .github/workflows/docker-smoke.yml` und in das Repository committed (`git commit -m "Add compose smoke check to CI"`).

### Testing
- Es wurden keine automatisierten Tests lokal ausgeführt, da es sich um eine CI-Workflow-Änderung handelt; die neue Compose-Job-Logik wird beim nächsten Main-Push oder einem nicht-fork PR in CI ausgeführt und dort automatisch getestet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967a99d5b2483338d9a8bcd5fefc2f0)