### PR TITLE
🧪 Micro: Small Improvement + Test: Improve DOCX Filename Sanitization

### DIFF
--- a/app/src/export/docx.ts
+++ b/app/src/export/docx.ts
@@ -428,9 +428,10 @@ const formatExportDate = (value: Date) =>
 const sanitizeFilenamePart = (value: string) =>
   value
     .trim()
-    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/[\\/:*?"<>|_]+/g, '-')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
     .slice(0, 80);
 
 /**
@@ -441,7 +442,7 @@ export const buildDocxExportFilename = (
   templateId: DocxTemplateId,
   exportedAt: Date = new Date(),
 ): string => {
-  const safeFormpack = sanitizeFilenamePart(formpackId || 'document');
+  const safeFormpack = sanitizeFilenamePart(formpackId) || 'document';
   const safeTemplate = sanitizeFilenamePart(templateId);
   return `${safeFormpack}-${safeTemplate}-${formatExportDate(exportedAt)}.docx`;
 };

--- a/app/tests/unit/export/docx.test.ts
+++ b/app/tests/unit/export/docx.test.ts
@@ -1,0 +1,44 @@
+// Tests for app/src/export/docx.ts
+import { describe, it, expect } from 'vitest';
+import { buildDocxExportFilename } from '../../../src/export/docx';
+
+describe('app/src/export/docx.ts', () => {
+  describe('buildDocxExportFilename()', () => {
+    const testDate = new Date('2023-10-26T10:00:00Z');
+
+    it('should generate a correctly formatted filename with valid inputs', () => {
+      const filename = buildDocxExportFilename(
+        'my-formpack',
+        'a4',
+        testDate,
+      );
+      expect(filename).toBe('my-formpack-a4-20231026.docx');
+    });
+
+    it('should sanitize special characters from formpackId and templateId', () => {
+      const filename = buildDocxExportFilename(
+        ' formpack/123?*<>|\\ ',
+        ' template/456?*<>|\\ ' as any,
+        testDate,
+      );
+      expect(filename).toBe('formpack-123-template-456-20231026.docx');
+    });
+
+    it('should default to "document" for an empty or whitespace formpackId', () => {
+      const filename1 = buildDocxExportFilename('', 'a4', testDate);
+      expect(filename1).toBe('document-a4-20231026.docx');
+
+      const filename2 = buildDocxExportFilename('   ', 'a4', testDate);
+      expect(filename2).toBe('document-a4-20231026.docx');
+    });
+
+    it('should handle leading/trailing characters that become hyphens', () => {
+      const filename = buildDocxExportFilename(
+        '__formpack__',
+        '**template**' as any,
+        testDate,
+      );
+      expect(filename).toBe('formpack-template-20231026.docx');
+    });
+  });
+});


### PR DESCRIPTION
### Problem
The `buildDocxExportFilename` function in `app/src/export/docx.ts` had two subtle bugs:
- It did not correctly sanitize filenames containing underscores (`_`).
- It failed to apply the "document" fallback for `formpackId`s that became empty *after* sanitization (e.g., an ID containing only spaces or special characters). This could lead to poorly formatted or invalid filenames. Additionally, this critical utility function was not covered by any unit tests, creating a risk of future regressions.

### Change (minimal)
- Updated the `sanitizeFilenamePart` regex to replace underscores (`_`) with hyphens.
- Refactored `buildDocxExportFilename` to apply the "document" fallback *after* sanitizing the `formpackId`, fixing the empty ID bug.
- Added a new test file `app/tests/unit/export/docx.test.ts`.

### Test (coverage)
- Added a comprehensive test suite for the `buildDocxExportFilename` function.
- The new tests cover:
    - Correct filename generation with valid inputs.
    - Sanitization of various special characters, including underscores.
    - The fallback behavior for empty and whitespace-only `formpackId`s.
- This introduces unit tests for a previously untested file, directly increasing the project's test coverage and robustness.

### Verification
- **Commands:**
  - `cd app && npm run lint`
  - `cd app && npm run typecheck`
  - `cd app && npm run build`
  - `cd app && npm run test`
- **Manual check:**
  - Go to any form.
  - Enter some data.
  - Click the "Export" button and select a DOCX format.
  - Verify that the downloaded file has a clean, correctly formatted name (e.g., `notfallpass-a4-YYYYMMDD.docx`).
  - The change is internal to filename generation, so as long as a valid file is downloaded, the fix is verified.

### Risk/Notes
- **Risk:** Very low. The change is confined to a single, pure utility function for generating filenames and is now protected by unit tests.
- **Notes:** The type-checking during the quality gate process failed because the new tests intentionally pass invalid data to the function to verify its sanitization logic. This was resolved by casting the invalid test inputs to `any`, which is a standard and safe practice for this type of testing.