### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting function

### DIFF
--- a/app/scripts/validate-formpacks.mjs
+++ b/app/scripts/validate-formpacks.mjs
@@ -115,16 +115,14 @@ const setPathValue = (target, pathValue, value) => {
     }
 
     cursor = cursor[segment];
-    // Abort if any segment is unsafe to prevent prototype pollution.
-    if (!segments.every((segment) => isSafePathSegment(segment))) {
-      return;
-    }
   });
 };
 
 const setNested = (target, dottedKey, value) => {
   const segments = dottedKey.split('.').filter(Boolean);
   if (!segments.length) return;
+  // Abort if any segment is unsafe to prevent prototype pollution.
+  if (!segments.every((segment) => isSafePathSegment(segment))) return;
 
   let cursor = target;
 


### PR DESCRIPTION
Potential fix for [https://github.com/WBT112/mecfs-paperwork/security/code-scanning/3](https://github.com/WBT112/mecfs-paperwork/security/code-scanning/3)

In general, the fix is to ensure that any deep assignment or merge function validates each path segment and refuses to create or set properties if the path contains dangerous keys such as `__proto__`, `constructor`, or `prototype`. This prevents an attacker from using user-controlled dotted paths to reach and modify `Object.prototype` or other critical prototypes.

For this file, the best fix is:

1. Keep and rely on the existing `isSafePathSegment` helper.
2. In `setPathValue`, simplify and strengthen the check: validate the `segments` array once at the start and, if any segment is unsafe, abort before performing any writes. Remove the redundant second `segments.every(...)` inside the loop; it does not add safety and may confuse static analysis.
3. In `setNested`, introduce the same validation: after splitting `dottedKey` into `segments`, abort if any segment fails `isSafePathSegment`. Then perform the loop exactly as before. This aligns `setNested` with `setPathValue` and closes another deep-assignment path that could be used for prototype pollution.
4. Do not change external behavior beyond rejecting obviously malicious paths; valid mappings using normal identifiers are unaffected.

All changes are within `app/scripts/validate-formpacks.mjs` around the definitions of `setPathValue` and `setNested`. No new imports or helper methods are required; we reuse the existing `isSafePathSegment`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
