### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting function

### DIFF
--- a/app/scripts/validate-formpacks.mjs
+++ b/app/scripts/validate-formpacks.mjs
@@ -87,6 +87,7 @@ const isSafeAssetPath = (value) => {
 };
 
 const isSafePathSegment = (segment) =>
+  segment &&
   segment !== '__proto__' &&
   segment !== 'constructor' &&
   segment !== 'prototype';
@@ -112,7 +113,8 @@ const setPathValue = (target, pathValue, value) => {
     }
 
     if (!isRecord(cursor[segment])) {
-      cursor[segment] = {};
+      // Create a prototype-less object to avoid prototype pollution.
+      cursor[segment] = Object.create(null);
     }
 
     cursor = cursor[segment];
@@ -135,7 +137,8 @@ const setNested = (target, dottedKey, value) => {
     }
 
     if (!isRecord(cursor[segment])) {
-      cursor[segment] = {};
+      // Create a prototype-less object to avoid prototype pollution.
+      cursor[segment] = Object.create(null);
     }
 
     cursor = cursor[segment];


### PR DESCRIPTION
Potential fix for [https://github.com/WBT112/mecfs-paperwork/security/code-scanning/3](https://github.com/WBT112/mecfs-paperwork/security/code-scanning/3)

In general, the problem is that `setPathValue` (and similarly `setNested`) performs deep assignment into `target` using path segments derived from potentially untrusted input, recursively creating nested objects and assigning `cursor[segment] = value` without guarding the *destination* object’s own properties beyond a simple name check. To robustly fix prototype pollution risks, the deep-assignment helper should: (1) block known-dangerous property names (`__proto__`, `constructor`, `prototype`), and (2) ensure it never assigns to inherited properties or accidentally walks through the object prototype chain. This can be done by using `Object.prototype.hasOwnProperty.call` to test for own properties, and by creating new nested objects using `Object.create(null)` or similar, so they have no prototype at all.

The best minimally invasive fix here is: (a) tighten `isSafePathSegment` by also rejecting empty string segments (which could arise from malformed paths) and continue blocking `__proto__`, `constructor`, and `prototype`; (b) in `setPathValue` and `setNested`, when creating intermediate objects, use `Object.create(null)` instead of `{}` to ensure there is no prototype chain that could be polluted; and (c) optionally, when deciding whether to traverse into an existing property, require that it be an own plain record (`isRecord`) and not an inherited property. These changes keep the externally visible behavior the same (nested objects are still plain key/value maps from the script’s perspective) but close off the paths that static analysis is concerned about. All changes are local to `app/scripts/validate-formpacks.mjs` within the shown region, and do not require new imports or external libraries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
