### PR TITLE
Render case paragraphs in Document Preview (support [[P]] markers and caseParagraphs)

### DIFF
--- a/app/e2e/doctor-letter.spec.ts
+++ b/app/e2e/doctor-letter.spec.ts
@@ -278,6 +278,30 @@ for (const locale of locales) {
       );
     });
 
+    test('doctor-letter preview renders case paragraphs', async ({ page }) => {
+      const translations = await loadTranslations(locale);
+      await openFreshDoctorLetter(page);
+      await switchLocale(page, locale);
+      await openDecisionTree(page, translations.app);
+      await answerDecisionTreeCase3(
+        page,
+        translations.formpack['doctor-letter.common.yes'],
+      );
+      const caseText = translations.formpack['doctor-letter.case.3.paragraph'];
+      await waitForResolvedText(page, caseText);
+
+      await openCollapsibleSection(
+        page,
+        new RegExp(translations.app.formpackDocumentPreviewHeading, 'i'),
+      );
+      const preview = page.locator('.formpack-document-preview');
+      const paragraphs = splitParagraphs(caseText);
+      for (const paragraph of paragraphs) {
+        await expect(preview.getByText(paragraph)).toBeVisible();
+      }
+      await expect(preview).not.toContainText('[[P]]');
+    });
+
     test('doctor-letter docx export works online and offline', async ({
       page,
       context,


### PR DESCRIPTION
### Motivation
- The Document Preview rendered decision/case text as a single block while DOCX exports used real paragraphs, making on-screen verification misleading.
- The preview must mirror exported DOCX paragraph structure by supporting `[[P]]` markers and the `decision.caseParagraphs` array while staying text-only and safe.

### Description
- Add paragraph normalization and rendering helpers in `FormpackDetailPage.tsx` to prefer `decision.caseParagraphs`, fall back to splitting on `[[P]]` or blank lines, and render paragraphs as `<p>` nodes instead of a single text block.
- Extend the preview resolver to return React nodes for decision case fields so the preview can render arrays of paragraphs and hide raw `[[P]]` markers.
- Support rendering `decision.caseParagraphs` arrays as paragraph sections in `renderPreviewArray` and treat `decision.caseText` / `decision.resolvedCaseText` as paragraph sources when present.
- Add automated coverage: a unit test in `app/tests/components/FormpackDetailPage.test.tsx` and an E2E test in `app/e2e/doctor-letter.spec.ts` that assert the preview shows paragraph breaks and does not display `[[P]]` markers.

### Testing
- Ran `npm ci` and `npm run format:check` which passed with no formatting issues. 
- Ran `npm run lint` and `npm run typecheck` which completed with no lint/type errors after refactoring cognitive-complexity; both passed.
- Ran unit tests with `npm test` and all unit tests passed (new unit test verifies paragraph rendering in the preview).
- Ran E2E tests with `npm run test:e2e` (soft-run); Chromium and WebKit runs passed including the new preview paragraphs test, while Firefox showed a known flaky failure in `autosave-reload` (one failure unrelated to these changes).
- Ran `npm run formpack:validate` and `npm run build` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697881cd334883338e69cda207598378)