### PR TITLE
Add Cache-Control headers for assets/formpacks, enable HSTS in Caddy, and add header smoke checks

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -79,6 +79,10 @@ jobs:
           curl -f http://localhost:8080/formpacks
           curl -f http://localhost:8080/some/deep/link
 
+      - name: Header smoke checks
+        if: steps.check-secrets.outputs.available == 'true'
+        run: node tools/header-smoke.mjs
+
       - name: Stop container
         if: always() && steps.check-secrets.outputs.available == 'true'
         run: docker stop mecfs-paperwork
@@ -144,6 +148,10 @@ jobs:
           curl -f http://localhost:8080/
           curl -f http://localhost:8080/formpacks
           curl -f http://localhost:8080/some/deep/link
+
+      - name: Compose header smoke checks
+        if: steps.check-secrets.outputs.available == 'true'
+        run: node tools/header-smoke.mjs
 
       - name: Compose down
         if: always() && steps.check-secrets.outputs.available == 'true'

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,14 @@
 # Replace the site address with your real domain (A/AAAA points to this server).
 # Example: mecfs-paperwork.de
 mecfs-paperwork.de {
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
   reverse_proxy web:8080
 }
 www.mecfs-paperwork.de {
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
   reverse_proxy web:8080
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,3 +1,9 @@
+map $uri $cache_control {
+  default "no-cache, must-revalidate";
+  ~^/assets/ "public, max-age=31536000, immutable";
+  ~^/formpacks/ "no-cache, must-revalidate";
+}
+
 server {
   listen 8080;
   server_name _;
@@ -5,11 +11,20 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  location /assets/ {
+    try_files $uri =404;
+  }
+
+  location /formpacks/ {
+    try_files $uri =404;
+  }
+
   location / {
     try_files $uri /index.html;
   }
 
   # Security headers
+  add_header Cache-Control $cache_control always;
   add_header X-Frame-Options "SAMEORIGIN" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header Referrer-Policy "no-referrer" always;

--- a/tools/header-smoke.mjs
+++ b/tools/header-smoke.mjs
@@ -1,0 +1,61 @@
+const baseUrl = process.env.HEADER_SMOKE_BASE_URL ?? 'http://localhost:8080';
+const formpackPath = '/formpacks/doctor-letter/manifest.json';
+
+const assertHeaderIncludes = (headerValue, expected, label) => {
+  if (!headerValue) {
+    throw new Error(`${label} header is missing.`);
+  }
+
+  const missing = expected.filter((token) => !headerValue.includes(token));
+  if (missing.length > 0) {
+    throw new Error(`${label} header missing tokens: ${missing.join(', ')} (got: ${headerValue}).`);
+  }
+};
+
+const fetchText = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}) for ${url}.`);
+  }
+  return { response, text: await response.text() };
+};
+
+const fetchHeaders = async (path, label) => {
+  const response = await fetch(`${baseUrl}${path}`);
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}) for ${label}.`);
+  }
+  return response.headers;
+};
+
+const findAssetPath = (html) => {
+  const match = html.match(/\/assets\/[^"']+\.(?:js|css)/);
+  if (!match) {
+    throw new Error('Unable to locate a hashed asset path in index.html.');
+  }
+  return match[0];
+};
+
+const run = async () => {
+  const { response: indexResponse, text: indexHtml } = await fetchText(`${baseUrl}/`);
+  const indexCache = indexResponse.headers.get('cache-control');
+  assertHeaderIncludes(indexCache, ['no-cache', 'must-revalidate'], 'index Cache-Control');
+
+  const formpackHeaders = await fetchHeaders(formpackPath, 'formpack manifest');
+  const formpackCache = formpackHeaders.get('cache-control');
+  assertHeaderIncludes(formpackCache, ['no-cache', 'must-revalidate'], 'formpack Cache-Control');
+
+  const assetPath = findAssetPath(indexHtml);
+  const assetHeaders = await fetchHeaders(assetPath, 'asset');
+  const assetCache = assetHeaders.get('cache-control');
+  assertHeaderIncludes(assetCache, ['max-age=31536000', 'immutable'], 'asset Cache-Control');
+
+  if (indexResponse.headers.has('strict-transport-security')) {
+    throw new Error('Strict-Transport-Security should not be set on HTTP responses.');
+  }
+};
+
+run().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Mobile clients sometimes served stale SPA shell or formpack JSON after deploys due to missing explicit cache headers. 
- The SPA shell (`index.html`) and formpack JSON must be forced to revalidate while hashed build assets can be cached long-term. 
- HSTS must be enforced at the TLS terminator (production) only to ensure HTTPS without breaking local HTTP-based smoke tests.

### Description
- Update `nginx/default.conf` to map requests to `Cache-Control` values and add `add_header Cache-Control $cache_control always;` with explicit handling for `/assets/` (long-term immutable), `/formpacks/` (no-cache, must-revalidate) and SPA routes (no-cache, must-revalidate). 
- Add `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` to the production `Caddyfile` for HTTPS-only HSTS enforcement. 
- Add `tools/header-smoke.mjs` which requests `/`, a formpack manifest, and a hashed asset to assert the expected `Cache-Control` headers and that `Strict-Transport-Security` is not present on HTTP responses. 
- Wire the header smoke script into the Docker smoke CI workflow by adding `Header smoke checks` and `Compose header smoke checks` steps that run `node tools/header-smoke.mjs` in `.github/workflows/docker-smoke.yml`.

### Testing
- A lightweight automated header smoke test was added to CI via the Docker smoke workflow and will run `node tools/header-smoke.mjs` as the `Header smoke checks` and `Compose header smoke checks` steps. 
- No automated tests were executed locally as part of this change; CI will run the smoke checks and report results. 
- To run the smoke check locally execute `node tools/header-smoke.mjs` (optionally set `HEADER_SMOKE_BASE_URL`) against a running instance and expect the script to exit non-zero on header mismatches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ea333a748333ad9f02317cf716ab)