### PR TITLE
test: assert DOCX XML breaks and marker absence

### DIFF
--- a/app/e2e/doctor-letter.spec.ts
+++ b/app/e2e/doctor-letter.spec.ts
@@ -250,8 +250,7 @@ const extractDocxDocumentXml = async (docxPath: string) => {
   return documentXml;
 };
 
-const extractDocxText = async (docxPath: string) => {
-  const documentXml = await extractDocxDocumentXml(docxPath);
+const extractDocxTextFromXml = (documentXml: string) => {
   const textRuns = Array.from(
     documentXml.matchAll(/<w:t[^>]*>([\s\S]*?)<\/w:t>/g),
   ).map((match) => match[1]);
@@ -406,10 +405,8 @@ test('doctor-letter resolves Case 14 and exports DOCX with case text', async ({
   const filePath = await download.path();
   expect(filePath).not.toBeNull();
   const docxPath = filePath as string;
-  const [docxText, documentXml] = await Promise.all([
-    extractDocxText(docxPath),
-    extractDocxDocumentXml(docxPath),
-  ]);
+  const documentXml = await extractDocxDocumentXml(docxPath);
+  const docxText = extractDocxTextFromXml(documentXml);
   expect(documentXml).not.toContain('[[P]]');
   expect(documentXml).not.toContain('[[BR]]');
   expect(documentXml).toContain('<w:br');


### PR DESCRIPTION
### Motivation
- Ensure DOCX exports not only contain the expected text but also preserve OOXML break semantics for cross-viewer compatibility.
- Prevent marker tokens (`[[P]]`, `[[BR]]`) from leaking into `word/document.xml` which could appear in exported DOCX files.

### Description
- Add `extractDocxDocumentXml(docxPath)` helper that returns the raw `word/document.xml` string. 
- Refactor `extractDocxText` to reuse `extractDocxDocumentXml` for text-run extraction. 
- Extend the Case 14 DOCX export E2E test to assert the exported `documentXml` does not contain `[[P]]` or `[[BR]]` and that it contains at least one `<w:br` break node, while keeping the existing loose text assertions. 
- Modified file: `app/e2e/doctor-letter.spec.ts`.

### Testing
- Ran formatting check with `cd app && npm run format:check` and it passed. 
- Ran lint and typecheck with `cd app && npm run lint` and `cd app && npm run typecheck` and both passed. 
- Ran unit tests with `cd app && npm test` and all unit tests passed (`397` tests passed). 
- Ran Playwright E2E with `cd app && npm run test:e2e` and all E2E tests passed (`37` tests passed). 
- Ran `cd app && npm run formpack:validate` and `cd app && npm run build` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b298e84e483338994ec0059a0ce57)