### PR TITLE
🛠️ Craftsman: Consolidate bespoke isRecord implementations

### DIFF
--- a/.jules/craftsman.md
+++ b/.jules/craftsman.md
@@ -1,0 +1,6 @@
+# Craftsman's Journal
+
+## 2026-01-30 - [Bespoke isRecord Consolidation]
+**Pattern:** Multiple local definitions of a basic `isRecord` type guard.
+**Learning:** Basic utilities like `isRecord` are often redefined locally in different modules to avoid dependency on a shared lib, leading to duplication and potential inconsistency.
+**Prevention:** Always check `app/src/lib/utils.ts` before implementing basic type guards or string helpers.

--- a/app/src/export/buildI18nContext.ts
+++ b/app/src/export/buildI18nContext.ts
@@ -1,11 +1,6 @@
 import i18n from '../i18n';
 import type { SupportedLocale } from '../i18n/locale';
-
-/**
- * Minimal "isRecord" helper to avoid relying on external utils and to harden input parsing.
- */
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
+import { isRecord } from '../lib/utils';
 
 /**
  * Sets a nested value on an object based on a dotted key path.

--- a/app/src/export/json.ts
+++ b/app/src/export/json.ts
@@ -3,6 +3,7 @@ import type { RJSFSchema } from '@rjsf/utils';
 import type { SupportedLocale } from '../i18n/locale';
 import type { FormpackManifest } from '../formpacks/types';
 import type { RecordEntry, SnapshotEntry } from '../storage/types';
+import { isRecord } from '../lib/utils';
 
 const APP_ID = 'mecfs-paperwork';
 const { version: appVersion } = appPackage as { version?: string };
@@ -40,9 +41,6 @@ export type JsonExportOptions = {
   exportedAt?: string;
   schema?: RJSFSchema;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const buildIsoDate = (
   year: number,

--- a/app/src/formpacks/documentModel.ts
+++ b/app/src/formpacks/documentModel.ts
@@ -1,5 +1,6 @@
 import i18n from '../i18n';
 import type { SupportedLocale } from '../i18n/locale';
+import { isRecord } from '../lib/utils';
 import { normalizeParagraphText } from '../lib/text/paragraphs';
 import { resolveDecisionTree, type DecisionAnswers } from './decisionEngine';
 
@@ -55,9 +56,6 @@ export type DocumentModel = {
     caseParagraphs: string[];
   };
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const getDiagnosisFlags = (
   formData: Record<string, unknown>,

--- a/app/src/import/json.ts
+++ b/app/src/import/json.ts
@@ -3,6 +3,7 @@ import addFormats from 'ajv-formats';
 import type { RJSFSchema } from '@rjsf/utils';
 import { isSupportedLocale, type SupportedLocale } from '../i18n/locale';
 import { FORMPACK_IDS } from '../formpacks/registry';
+import { isRecord } from '../lib/utils';
 
 type ImportFormpackMetadata = {
   id: string;
@@ -50,9 +51,6 @@ export type ImportError = {
 export type ImportValidationResult =
   | { payload: JsonImportPayload; error: null }
   | { payload: null; error: ImportError };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const parseJson = (
   value: string,

--- a/app/src/lib/rjsfDoctorLetterFieldTemplate.tsx
+++ b/app/src/lib/rjsfDoctorLetterFieldTemplate.tsx
@@ -1,5 +1,6 @@
 import type { FieldTemplateProps } from '@rjsf/utils';
 import type { TFunction } from 'i18next';
+import { isRecord } from './utils';
 import { InfoBox } from '../components/InfoBox';
 import { getInfoBoxesForField } from '../formpacks/doctorLetterInfoBox';
 import type { InfoBoxConfig } from '../formpacks/types';
@@ -17,9 +18,6 @@ type DoctorLetterFormContext = {
   infoBoxes?: InfoBoxConfig[];
   formData?: Record<string, unknown>;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
 
 const isTranslator = (value: unknown): value is TFunction =>
   typeof value === 'function';


### PR DESCRIPTION
### Summary
Consolidated multiple bespoke implementations of the `isRecord` utility function into a single, shared helper in `app/src/lib/utils.ts`.

### Change List
- ✅ Replaced local `isRecord` definitions with imports from `app/src/lib/utils.ts` in:
  - `app/src/formpacks/documentModel.ts`
  - `app/src/import/json.ts`
  - `app/src/lib/rjsfDoctorLetterFieldTemplate.tsx`
  - `app/src/export/json.ts`
  - `app/src/export/buildI18nContext.ts`
- 📝 Updated `.jules/craftsman.md` with learnings.

### Security Angle
Reduces the risk of inconsistent type checking across different modules, ensuring a unified and tested approach to object validation.

### Risk & Compatibility
Low risk. The shared `isRecord` implementation is already used in other parts of the app and is more robust (excludes arrays) than some of the replaced versions (specifically in `rjsfDoctorLetterFieldTemplate.tsx`), leading to stricter and safer type checks.

### Test Evidence
Full quality gates passed from `/app`:
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm test` ✅
- `npm run formpack:validate` ✅
- `npm run build` ✅
- `npm run test:e2e` (Firefox flakiness acknowledged) ✅

### Next candidates
- Standardize filename sanitization across export modules.
- Replace bespoke nested path access (`getNested`/`setNested`) with unified helpers.
- Standardize date normalization logic.

---
*PR created automatically by Jules for task [17443901379574917691](https://jules.google.com/task/17443901379574917691) started by @WBT112*