### PR TITLE
🎨 Palette: UI/UX Polish: Update help page with PDF export and English localization

### DIFF
--- a/app/src/content/help/help.en.md
+++ b/app/src/content/help/help.en.md
@@ -1,0 +1,168 @@
+# Help
+
+This application helps you to **create forms and documents in a structured way** – step by step.
+At the end, you can export a **DOCX document** (for further editing) or a **PDF file** (for direct sharing/printing).
+
+> Privacy Note: Please do **not enter sensitive health data** in public areas (e.g., GitHub issues, support emails, screenshots). Handle exports carefully.
+
+---
+
+## 1) Basic Principle: Formpacks, Drafts, and Result
+
+- **Formpack**: A subject area / template (e.g., "Doctor's Letter").
+- **Draft**: Your current work on a case – you can continue editing at any time.
+- **Result**: The generated text arising from your answers (which ends up in the DOCX/PDF).
+
+Typical Workflow:
+
+1. Select a Formpack
+2. Answer questions
+3. Use **Tools** if necessary (Drafts/Snapshots/JSON Export/Import)
+4. Check the result
+5. **Export DOCX or PDF**
+6. Open the file, complement if necessary, save/share
+
+---
+
+## 2) Tools: What are they for?
+
+### Drafts
+
+A draft is your current processing status.
+
+- Use drafts if you want to work on the same document over several days.
+- Save regularly, especially before making major changes.
+- A draft can contain several snapshots.
+- The active draft is automatically saved and cannot be deleted.
+- You can delete inactive drafts. Associated snapshots will also be removed.
+- Deletions only occur locally on this device/browser and cannot be undone.
+
+### Snapshots
+
+Snapshots are **intermediate states** (like "backups") that you can restore later.
+
+- Create a snapshot **before** risky changes (e.g., when you change many fields at once).
+- All snapshots of a draft can be completely deleted if necessary.
+
+### Export JSON (Backup/Share)
+
+With JSON export, you save your entries as a file.
+
+- Ideal as a **backup** (e.g., before you change devices/browsers).
+- Useful if you want to import a case again later.
+
+### Import JSON (Restore/Transfer)
+
+With import, you load a previously exported JSON file back into the app.
+
+- Good for moving to another device or if you want to restore from a backup.
+- If there is an "Overwrite active draft" option: use it only deliberately if you really want to replace the current status.
+
+---
+
+## 3) Export: DOCX & PDF – what do I get?
+
+### DOCX (Word format)
+
+Ideal if you want to **continue editing** the text.
+
+- Open the text on a PC or smartphone,
+- make final additions/adjustments,
+- and then share the file as DOCX or PDF.
+
+### PDF
+
+Ideal if you want to **print or send** the document directly.
+
+- The layout is fixed and looks the same everywhere.
+- No further editing possible (without special tools).
+
+Recommendation:
+
+- After export, save the file **under a clear name**, e.g.:
+  `doctors_letter_2026-01-26.docx`
+
+---
+
+## 4) Further Editing DOCX on PC (Windows / macOS / Linux)
+
+Common options:
+
+- **Microsoft Word** (Desktop)
+- **LibreOffice Writer** (free)
+- **Google Docs** (in the browser – editing Word files possible)
+
+Practical Tip:
+
+- If layout/page breaks are important, a desktop editor is often the most stable.
+- After opening: briefly check if paragraphs, lists, and page breaks look correct.
+
+---
+
+## 5) DOCX on Smartphone / Tablet (Android)
+
+Common options:
+
+- **Microsoft Word** (Android)
+- **Google Docs** (Android)
+- **ONLYOFFICE Documents** (Android)
+
+Typical Workflow:
+
+1. Open DOCX file (Downloads/File Manager/Cloud)
+2. "Open with ..." → select desired app
+3. Save changes (some apps create a copy – this is normal)
+
+---
+
+## 6) DOCX on iPhone / iPad (iOS)
+
+Common options:
+
+- **Microsoft Word** (iOS)
+- **Pages** (iOS – can open and edit DOCX)
+- **Google Docs** (iOS)
+- **ONLYOFFICE Documents** (iOS)
+
+Typical Workflow:
+
+1. Find file in the "Files" app (or open from Mail/Cloud)
+2. Share/Open → select app (Word/Pages/etc.)
+3. Save – if necessary as a copy
+
+---
+
+## 7) Frequently Asked Questions / Troubleshooting
+
+**"I can no longer see my draft."**
+
+- Check if you are in the correct support offer (Formpack).
+- Look in Drafts/Snapshots to see if an intermediate state exists.
+- Did you change devices? Data is only stored on the current device.
+
+**"I can't find the exported file."**
+
+- Check: Downloads folder / Files app / Cloud storage (e.g., iCloud Drive, Google Drive).
+
+**"The layout is messed up."**
+
+- Try opening the DOCX in another app (e.g., Word instead of an alternative app).
+- After saving, check if paragraphs/lists/page breaks are correct.
+
+**"I only want to print/send."**
+
+- Export directly as PDF.
+
+**"Something isn't working or I don't see support offer XYZ"**
+
+- Reload the page.
+- Try it again in a "Private Window" (Note: data might not be saved there).
+- If that doesn't help: contact us via the feedback button.
+
+---
+
+## 8) Privacy & Secure Working Method
+
+- Before sharing a DOCX/PDF/JSON, check if it contains content you do not want to pass on.
+- No further data is exchanged between your device and the server after the page has loaded (except for checking for formpack updates).
+- If you also want to delete the stored data in your browser, this is usually done via history/clear browser data or similar, depending on the browser.

--- a/app/src/content/help/help.md
+++ b/app/src/content/help/help.md
@@ -1,7 +1,7 @@
 # Hilfe
 
 Diese Anwendung hilft dir, **Formulare und Schreiben strukturiert zu erstellen** – Schritt für Schritt.
-Am Ende kannst du ein **DOCX-Dokument exportieren**, das du am PC oder Smartphone weiterbearbeiten und versenden kannst.
+Am Ende kannst du ein **DOCX-Dokument** (zur Weiterbearbeitung) oder eine **PDF-Datei** (zum direkten Versenden/Drucken) exportieren.
 
 > Datenschutz-Hinweis: Bitte gib **keine sensiblen Gesundheitsdaten** in öffentliche Bereiche (z. B. GitHub-Issues, Support-Mails, Screenshots) ein. Behandle Exporte sorgfältig.
 
@@ -11,7 +11,7 @@ Am Ende kannst du ein **DOCX-Dokument exportieren**, das du am PC oder Smartphon
 
 - **Formpack**: Ein Themenbereich / eine Vorlage (z. B. „Arztbrief“).
 - **Entwurf**: Deine aktuelle Arbeit an einem Fall – du kannst jederzeit weiterbearbeiten.
-- **Ergebnis**: Der generierte Text, der aus deinen Antworten entsteht (und im DOCX landet).
+- **Ergebnis**: Der generierte Text, der aus deinen Antworten entsteht (und im DOCX/PDF landet).
 
 Typischer Ablauf:
 
@@ -19,7 +19,7 @@ Typischer Ablauf:
 2. Fragen beantworten
 3. ggf. **Tools** nutzen (Entwürfe/Snapshots/JSON Export/Import)
 4. Ergebnis prüfen
-5. **DOCX exportieren**
+5. **DOCX oder PDF exportieren**
 6. Datei öffnen, ggf. ergänzen, speichern/teilen
 
 ---
@@ -32,14 +32,14 @@ Ein Entwurf ist dein laufender Bearbeitungsstand.
 
 - Nutze Entwürfe, wenn du über mehrere Tage am selben Dokument arbeiten willst.
 - Speichere regelmäßig, besonders vor größeren Änderungen.
-- Ein Entwurf kann mehrere Snapshots enthalten
+- Ein Entwurf kann mehrere Snapshots enthalten.
 - Der aktive Entwurf wird automatisch gespeichert und kann nicht gelöscht werden.
 - Du kannst nicht aktive Entwürfe löschen. Dabei werden zugehörige Snapshots ebenfalls entfernt.
 - Löschungen erfolgen nur lokal auf diesem Gerät/Browser und sind nicht rückgängig zu machen.
 
 ### Snapshots
 
-Snapshots sind **Zwischenstände** (wie “Sicherungen”), die du später wiederherstellen kannst.
+Snapshots sind **Zwischenstände** (wie „Sicherungen“), die du später wiederherstellen kannst.
 
 - Erstelle einen Snapshot **vor** riskanten Änderungen (z. B. wenn du viele Felder auf einmal änderst).
 - Alle Snapshots eines Entwurfs können bei Bedarf vollständig gelöscht werden.
@@ -60,14 +60,22 @@ Mit dem Import lädst du eine zuvor exportierte JSON-Datei wieder in die App.
 
 ---
 
-## 3) Export: DOCX – was kommt da raus?
+## 3) Export: DOCX & PDF – was kommt da raus?
 
-Beim Export erhältst du eine **DOCX-Datei** (Word-Format).
-Damit kannst du:
+### DOCX (Word-Format)
 
-- den Text am PC oder Smartphone öffnen,
-- letzte Ergänzungen/Anpassungen machen,
-- und die Datei anschließend als DOCX oder PDF weitergeben.
+Ideal, wenn du den Text noch **weiterbearbeiten** möchtest.
+
+- Öffne den Text am PC oder Smartphone,
+- mache letzte Ergänzungen/Anpassungen,
+- und gib die Datei anschließend als DOCX oder PDF weiter.
+
+### PDF
+
+Ideal, wenn du das Dokument direkt **drucken oder versenden** möchtest.
+
+- Das Layout ist fest und sieht überall gleich aus.
+- Keine weitere Bearbeitung möglich (ohne Spezialwerkzeuge).
 
 Empfehlung:
 
@@ -128,9 +136,9 @@ Typischer Ablauf:
 
 **„Ich sehe meinen Entwurf nicht mehr.“**
 
-- Prüfe, ob du im richtigen Hilfsangebot bist.
+- Prüfe, ob du im richtigen Hilfsangebot (Formpack) bist.
 - Schau in Entwürfe/Snapshots, ob ein Zwischenstand vorhanden ist.
-- Hast du das Gerät gewechselt ? Daten werden nur auf dem aktuellen Gerät gespeichert.
+- Hast du das Gerät gewechselt? Daten werden nur auf dem aktuellen Gerät gespeichert.
 
 **„Ich finde die exportierte Datei nicht.“**
 
@@ -143,18 +151,18 @@ Typischer Ablauf:
 
 **„Ich will nur drucken/versenden.“**
 
-- Exportiere direkt als PDF
+- Exportiere direkt als PDF.
 
 **„Etwas funktioniert nicht oder ich sehe Hilfsangebot XYZ nicht“**
 
-- Lade die Seite neu
-- Versuche das ganze nochmal in einem "Privaten Fenster"
-- Wenn das nicht hilft: kontaktier uns über den Feedback-Button
+- Lade die Seite neu.
+- Versuche das ganze nochmal in einem „Privaten Fenster“ (Hinweis: Daten werden dort ggf. nicht gespeichert).
+- Wenn das nicht hilft: kontaktier uns über den Feedback-Button.
 
 ---
 
 ## 8) Datenschutz & sichere Arbeitsweise
 
 - Prüfe vor dem Teilen eines DOCX/PDF/JSON, ob Inhalte enthalten sind, die du nicht weitergeben möchtest.
-- Es werden nach dem Laden der Seite keine weiteren Daten zwischen deinem Gerät und dem Server ausgetauscht.
+- Es werden nach dem Laden der Seite keine weiteren Daten zwischen deinem Gerät und dem Server ausgetauscht (außer zur Prüfung auf Formpack-Updates).
 - Wenn du die gespeicherten Daten in deinem Browser ebenfalls löschen möchtest, geht das je nach Browser meist über Verlauf/Browserdaten löschen oder ähnliches.

--- a/app/src/pages/HelpPage.tsx
+++ b/app/src/pages/HelpPage.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MarkdownRenderer from '../components/Markdown/MarkdownRenderer';
-import helpContent from '../content/help/help.md?raw';
+import helpDe from '../content/help/help.md?raw';
+import helpEn from '../content/help/help.en.md?raw';
 import { APP_VERSION, BUILD_DATE_ISO, formatBuildDate } from '../lib/version';
 import {
   downloadDiagnosticsBundle,
@@ -154,18 +155,20 @@ export default function HelpPage() {
   );
 
   const downloadLabel =
-    diagState === 'downloading'
-      ? t('diagnosticsDownloading')
-      : diagState === 'downloaded'
-        ? t('diagnosticsDownloaded')
-        : t('diagnosticsDownload');
+    (
+      {
+        downloading: t('diagnosticsDownloading'),
+        downloaded: t('diagnosticsDownloaded'),
+      } as Record<string, string>
+    )[diagState] ?? t('diagnosticsDownload');
 
   const copyLabel =
-    diagState === 'copied'
-      ? t('diagnosticsCopied')
-      : diagState === 'failed'
-        ? t('diagnosticsCopyFailed')
-        : t('diagnosticsCopy');
+    (
+      {
+        copied: t('diagnosticsCopied'),
+        failed: t('diagnosticsCopyFailed'),
+      } as Record<string, string>
+    )[diagState] ?? t('diagnosticsCopy');
 
   const idbStatusLabel = health.indexedDbAvailable
     ? t('storageHealthIdbAvailable')
@@ -180,6 +183,8 @@ export default function HelpPage() {
   const versionCopyLabel = copied
     ? t('versionInfoCopied')
     : t('versionInfoCopy');
+
+  const helpContent = i18n.language === 'en' ? helpEn : helpDe;
 
   return (
     <section className="app__card legal-page help-page">

--- a/app/tests/components/HelpPage.test.tsx
+++ b/app/tests/components/HelpPage.test.tsx
@@ -94,12 +94,14 @@ describe('HelpPage', () => {
     });
   });
 
-  it('renders the main help heading from markdown', () => {
+  it('renders the main help heading from markdown', async () => {
     render(<HelpPage />);
 
-    expect(
-      screen.getByRole('heading', { level: 1, name: /hilfe/i }),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: /help/i }),
+      ).toBeInTheDocument();
+    });
     expect(
       screen.getByRole('heading', { name: 'versionInfoTitle' }),
     ).toBeVisible();
@@ -267,7 +269,7 @@ describe('HelpPage', () => {
   });
 
   describe('storage health display', () => {
-    it('shows loading state when health check is pending', () => {
+    it('shows loading state when health check is pending', async () => {
       mockHealthState = {
         ...mockHealthState,
         loading: true,
@@ -275,21 +277,23 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      expect(screen.getByText('storageHealthLoading')).toBeInTheDocument();
+      expect(
+        await screen.findByText('storageHealthLoading'),
+      ).toBeInTheDocument();
       expect(
         screen.queryByTestId(TID_STORAGE_HEALTH_STATUS),
       ).not.toBeInTheDocument();
     });
 
-    it('displays ok status when storage is healthy', () => {
+    it('displays ok status when storage is healthy', async () => {
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveAttribute(ATTR_DATA_STATUS, 'ok');
       expect(statusEl).toHaveTextContent('storageHealthStatusOk');
     });
 
-    it('displays warning status and guidance message', () => {
+    it('displays warning status and guidance message', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -302,7 +306,7 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveAttribute(ATTR_DATA_STATUS, 'warning');
       expect(statusEl).toHaveTextContent('storageHealthStatusWarning');
 
@@ -311,7 +315,7 @@ describe('HelpPage', () => {
       );
     });
 
-    it('displays error status and guidance message', () => {
+    it('displays error status and guidance message', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -324,7 +328,7 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveAttribute(ATTR_DATA_STATUS, 'error');
       expect(statusEl).toHaveTextContent('storageHealthStatusError');
 
@@ -333,20 +337,21 @@ describe('HelpPage', () => {
       );
     });
 
-    it('does not show guidance message when status is ok', () => {
+    it('does not show guidance message when status is ok', async () => {
       render(<HelpPage />);
+      await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
 
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
-    it('displays storage quota as formatted bytes when supported', () => {
+    it('displays storage quota as formatted bytes when supported', async () => {
       render(<HelpPage />);
 
-      const quotaEl = screen.getByTestId(TID_STORAGE_HEALTH_QUOTA);
+      const quotaEl = await screen.findByTestId(TID_STORAGE_HEALTH_QUOTA);
       expect(quotaEl).toHaveTextContent('4.9 KB / 97.7 KB');
     });
 
-    it('displays unsupported message when storage estimate is not available', () => {
+    it('displays unsupported message when storage estimate is not available', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -357,19 +362,19 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const quotaEl = screen.getByTestId(TID_STORAGE_HEALTH_QUOTA);
+      const quotaEl = await screen.findByTestId(TID_STORAGE_HEALTH_QUOTA);
       expect(quotaEl).toHaveTextContent('storageHealthQuotaUnsupported');
     });
 
-    it('shows IDB available status', () => {
+    it('shows IDB available status', async () => {
       render(<HelpPage />);
 
-      const idbEl = screen.getByTestId('storage-health-idb');
+      const idbEl = await screen.findByTestId('storage-health-idb');
       expect(idbEl).toHaveAttribute(ATTR_DATA_STATUS, 'available');
       expect(idbEl).toHaveTextContent('storageHealthIdbAvailable');
     });
 
-    it('shows IDB unavailable status', () => {
+    it('shows IDB unavailable status', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -380,15 +385,15 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const idbEl = screen.getByTestId('storage-health-idb');
+      const idbEl = await screen.findByTestId('storage-health-idb');
       expect(idbEl).toHaveAttribute(ATTR_DATA_STATUS, 'unavailable');
       expect(idbEl).toHaveTextContent('storageHealthIdbUnavailable');
     });
 
-    it('calls refresh when the refresh button is clicked', () => {
+    it('calls refresh when the refresh button is clicked', async () => {
       render(<HelpPage />);
 
-      const refreshButton = screen.getByRole('button', {
+      const refreshButton = await screen.findByRole('button', {
         name: 'storageHealthRefresh',
       });
       fireEvent.click(refreshButton);
@@ -398,7 +403,7 @@ describe('HelpPage', () => {
   });
 
   describe('formatBytes', () => {
-    it('formats bytes correctly', () => {
+    it('formats bytes correctly', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -409,11 +414,11 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const quotaEl = screen.getByTestId(TID_STORAGE_HEALTH_QUOTA);
+      const quotaEl = await screen.findByTestId(TID_STORAGE_HEALTH_QUOTA);
       expect(quotaEl).toHaveTextContent('500 B / 1.0 KB');
     });
 
-    it('formats kilobytes correctly', () => {
+    it('formats kilobytes correctly', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -424,11 +429,11 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const quotaEl = screen.getByTestId(TID_STORAGE_HEALTH_QUOTA);
+      const quotaEl = await screen.findByTestId(TID_STORAGE_HEALTH_QUOTA);
       expect(quotaEl).toHaveTextContent('2.0 KB / 500.0 KB');
     });
 
-    it('formats megabytes correctly', () => {
+    it('formats megabytes correctly', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -443,20 +448,20 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const quotaEl = screen.getByTestId(TID_STORAGE_HEALTH_QUOTA);
+      const quotaEl = await screen.findByTestId(TID_STORAGE_HEALTH_QUOTA);
       expect(quotaEl).toHaveTextContent('5.0 MB / 100.0 MB');
     });
   });
 
   describe('statusLabel', () => {
-    it('returns ok label', () => {
+    it('returns ok label', async () => {
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveTextContent('storageHealthStatusOk');
     });
 
-    it('returns warning label', () => {
+    it('returns warning label', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -468,11 +473,11 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveTextContent('storageHealthStatusWarning');
     });
 
-    it('returns error label', () => {
+    it('returns error label', async () => {
       mockHealthState = {
         ...mockHealthState,
         health: {
@@ -484,24 +489,24 @@ describe('HelpPage', () => {
 
       render(<HelpPage />);
 
-      const statusEl = screen.getByTestId(TID_STORAGE_HEALTH_STATUS);
+      const statusEl = await screen.findByTestId(TID_STORAGE_HEALTH_STATUS);
       expect(statusEl).toHaveTextContent('storageHealthStatusError');
     });
   });
 
   describe('reset all local data', () => {
-    it('renders the danger zone section', () => {
+    it('renders the danger zone section', async () => {
       render(<HelpPage />);
 
-      expect(screen.getByTestId('danger-zone')).toBeInTheDocument();
+      expect(await screen.findByTestId('danger-zone')).toBeInTheDocument();
       expect(screen.getByTestId(TID_RESET_ALL_DATA)).toBeInTheDocument();
     });
 
-    it('shows confirm dialog on button click and does nothing on cancel', () => {
+    it('shows confirm dialog on button click and does nothing on cancel', async () => {
       const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
 
       render(<HelpPage />);
-      fireEvent.click(screen.getByTestId(TID_RESET_ALL_DATA));
+      fireEvent.click(await screen.findByTestId(TID_RESET_ALL_DATA));
 
       expect(confirmSpy).toHaveBeenCalledWith('resetAllConfirm');
       expect(mockResetAllLocalData).not.toHaveBeenCalled();
@@ -511,7 +516,7 @@ describe('HelpPage', () => {
       vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
 
       render(<HelpPage />);
-      fireEvent.click(screen.getByTestId(TID_RESET_ALL_DATA));
+      fireEvent.click(await screen.findByTestId(TID_RESET_ALL_DATA));
 
       await waitFor(() => {
         expect(mockResetAllLocalData).toHaveBeenCalledOnce();
@@ -528,7 +533,7 @@ describe('HelpPage', () => {
       );
 
       render(<HelpPage />);
-      const button = screen.getByTestId(TID_RESET_ALL_DATA);
+      const button = await screen.findByTestId(TID_RESET_ALL_DATA);
       fireEvent.click(button);
 
       await waitFor(() => {
@@ -544,7 +549,7 @@ describe('HelpPage', () => {
       mockResetAllLocalData.mockRejectedValue(new Error('fail'));
 
       render(<HelpPage />);
-      const button = screen.getByTestId(TID_RESET_ALL_DATA);
+      const button = await screen.findByTestId(TID_RESET_ALL_DATA);
       fireEvent.click(button);
 
       await waitFor(() => {


### PR DESCRIPTION
This PR updates the Help page to include information about the new PDF export feature and introduces full English localization for the help content.

Key changes:
- Updated `app/src/content/help/help.md` (German) to mention PDF export in the introduction, typical workflow, and a new dedicated section explaining the difference between DOCX and PDF.
- Created `app/src/content/help/help.en.md` with a full English translation of the updated help content.
- Updated `app/src/pages/HelpPage.tsx` to dynamically switch between German and English markdown content based on the active locale.
- Refactored `HelpPage.tsx` to reduce cognitive complexity by using object lookups for labels instead of nested ternaries.
- Updated `app/tests/components/HelpPage.test.tsx` to support the localized content and fixed `act()` warnings by using asynchronous `findBy`/`waitFor` queries.

Verified visually in both German and English via Playwright screenshots.

---
*PR created automatically by Jules for task [15140482748844246477](https://jules.google.com/task/15140482748844246477) started by @WBT112*