### PR TITLE
🏗️ArchitectureNotes: fix incorrect IndexedDB store names in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,6 @@ Do not block feature work on this unless the issue explicitly targets security t
   - Run npm run format before opening PRs if format:check fails.
 
 ## 9) Data model constraints (MVP)
-- Storage: IndexedDB with `records` + `revisions` (snapshots). Keep migrations explicit.
+- Storage: IndexedDB (`mecfs-paperwork`, v3) with four stores: `records`, `snapshots`, `formpackMeta`, `profiles`. Keep migrations explicit (bump `DB_VERSION` in `app/src/storage/db.ts`).
 - Export: primary DOCX (A4 + Wallet as separate downloads), plus JSON backup/import.
 - i18n: DE + EN from the start; locale stored per record and kept in exports.


### PR DESCRIPTION
## Summary

- Fix incorrect IndexedDB store name in `AGENTS.md` data model section: `revisions` → `snapshots`
- Add two missing stores: `formpackMeta` and `profiles`
- Add DB name (`mecfs-paperwork`) and version (`v3`) for precision

## Diff

```diff
- Storage: IndexedDB with `records` + `revisions` (snapshots). Keep migrations explicit.
+ Storage: IndexedDB (`mecfs-paperwork`, v3) with four stores: `records`, `snapshots`, `formpackMeta`, `profiles`. Keep migrations explicit (bump `DB_VERSION` in `app/src/storage/db.ts`).
```

## Why meaningful

An AI agent reading `AGENTS.md` would use the wrong store name `revisions` when generating storage code or tests. The actual store has always been called `snapshots` (see `app/src/storage/db.ts`). The two missing stores (`formpackMeta`, `profiles`) are actively used in production.

## Files changed

- `AGENTS.md` (1 line)

## Verification

| Gate | Result |
|------|--------|
| `npm run lint` | Pre-existing eslint-plugin-jsx-a11y error (staging baseline) |
| `npm run format:check` | ✅ All matched files use Prettier code style |
| `npm run typecheck` | ✅ Pass |
| `npm test` | ✅ 122 files, 982 tests passed |
| `npm run formpack:validate` | ✅ Formpack validation passed |
| `npm run build` | ✅ Built in 3.97s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)